### PR TITLE
entity:make-from-description可以导入字段注释了

### DIFF
--- a/command/entity.php
+++ b/command/entity.php
@@ -232,7 +232,10 @@ drop table `%s`;";
             } else {
                 $column .= " DEFAULT $default";
             }
-        } 
+        }
+        if (!empty($struct['description'])) {
+            $column .= " COMMENT \"{$struct['description']}\"";
+        }
         $columns[] = $column.',';
     }
 


### PR DESCRIPTION
假如yaml中包括字段文字注释，那么生成的SQL将包含这些注释：

    # up
    CREATE TABLE `project_budget` (
        `id` bigint(20) NOT NULL,
        `version` int(11) NOT NULL,
        `create_time` datetime DEFAULT NULL,
        `update_time` datetime DEFAULT NULL,
        `delete_time` datetime DEFAULT NULL,
        `project_name` varchar(255) NOT NULL DEFAULT '' COMMENT "项目名称",
        `project_id` int(11) NOT NULL DEFAULT '0' COMMENT "项目ID",
        `year` int(4) NOT NULL DEFAULT '0' COMMENT "年份",
        `month` varchar(255) NOT NULL DEFAULT '' COMMENT "月预算，元",
        `create_user_id` bigint(20) NOT NULL DEFAULT '0' COMMENT "创建记录者用户ID",
        `create_user_name` varchar(255) NOT NULL DEFAULT '' COMMENT "创建记录者用户名",
        PRIMARY KEY (`id`)
    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

    # down
    drop table `project_budget`;

测试导入成功

    > php cli.php migrate        
    2019_02_01_12_23_47_department.sql up!
    2019_02_01_12_23_47_file.sql up!
    2019_02_01_12_23_47_project.sql up!
    2019_02_01_12_23_47_project_budget.sql up!
    2019_02_01_12_23_47_project_needs.sql up!
    2019_02_01_12_23_47_project_version.sql up!
    2019_02_01_12_23_47_project_version_quality_score.sql up!
    2019_02_01_12_23_47_quality_assessment_indicator_manage.sql up!
    2019_02_01_12_23_47_satisfactions.sql up!
    2019_02_01_12_23_47_score_coefficient_manage.sql up!
    2019_02_01_12_23_47_score_manager_project.sql up!
    2019_02_01_12_23_47_user.sql up!
    2019_02_01_12_23_47_user_flow_log.sql up!
    2019_02_01_12_23_47_worktime_department.sql up!
    2019_02_01_12_23_47_worktime_person.sql up!
    2019_02_01_12_23_47_worktime_project.sql up!
    2019_02_01_12_23_47_worktime_supplement.sql up!